### PR TITLE
conf(renovate): enable grouped updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,4 +16,23 @@
     enabled: true,
   },
   reviewers: ["freinold", "a-wittmann", "shteenft"],
-} 
+  packageRules: [
+    {
+      matchManagers: ["pep621"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "Python: non-major updates",
+      groupSlug: "python-non-major",
+      matchDepNames: ["!python"],
+    },
+    {
+      matchManagers: ["dockerfile"],
+      groupName: "Dockerfile base images",
+      groupSlug: "dockerfile-base-images",
+    },
+    {
+      matchManagers: ["github-actions"],
+      groupName: "GitHub Actions dependencies",
+      groupSlug: "github-actions",
+    },
+  ],
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to group related changes:
    - Group non-major Python dependency updates together (excluding the core Python runtime).
    - Group Dockerfile base image updates together.
    - Group GitHub Actions dependency updates together.
  * Improves clarity and reduces noise in automated update PRs. No impact on product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->