### PR TITLE
fix(backend): make db schema for vectorstore configurable

### DIFF
--- a/riski-backend/app/backend.py
+++ b/riski-backend/app/backend.py
@@ -85,6 +85,7 @@ async def build_vectorstore(settings) -> tuple[PGVectorStore, PGEngine]:
     embedding_model = create_embedding_model(settings)
     vectorstore = await PGVectorStore.create(
         engine=pg_engine,
+        schema_name=settings.core.db.schema,
         table_name="file",
         embedding_service=embedding_model,
         id_column="db_id",

--- a/riski-core/src/core/settings/db.py
+++ b/riski-core/src/core/settings/db.py
@@ -32,6 +32,10 @@ class DatabaseSettings(BaseModel):
         description="Batch size for database operations",
         default=100,
     )
+    schema: str = Field(
+        description="Postgres schema used for vectorstore",
+        default="public",
+    )
 
     @property
     def database_url(self) -> PostgresDsn:


### PR DESCRIPTION
**Description**

Short description or comments

**Reference**

Issues #XXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PostgreSQL schema configuration for vector store operations. Users can now specify the database schema through settings, with a default of "public" for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->