### PR TITLE
Don't use stale connections

### DIFF
--- a/riski-backend/app/backend.py
+++ b/riski-backend/app/backend.py
@@ -30,6 +30,8 @@ def create_app() -> FastAPI:
             url=settings.core.db.async_database_url.encoded_string(),
             echo=True,
             pool_timeout=10,
+            pool_pre_ping=True,
+            pool_recycle=1800,
             connect_args={"timeout": 30},
         )
 


### PR DESCRIPTION
Avoid stale connection errors by
- Recycle connections
- Pre-Ping to test if a connection is stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database connection pool management with connection health checks and automatic recycling to improve system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->