### PR TITLE
No more in mem checkpointer

### DIFF
--- a/riski-backend/app/core/settings.py
+++ b/riski-backend/app/core/settings.py
@@ -2,52 +2,12 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field, RedisDsn, SecretStr, field_validator
 from pydantic_settings import SettingsConfigDict
 
 from core.settings.base import AppBaseSettings
-
-
-class RedisCheckpointerSettings(BaseModel):
-    type: Literal["redis"] = "redis"
-    host: str = Field(
-        default="localhost",
-        description="Redis host for checkpointer",
-    )
-    port: int = Field(
-        default=6379,
-        description="Redis port for checkpointer",
-    )
-    db: int = Field(
-        default=0,
-        description="Redis database number for checkpointer",
-    )
-    password: SecretStr | None = Field(
-        default=None,
-        description="Redis password for checkpointer",
-    )
-    secure: bool = Field(
-        default=False,
-        description="Use SSL/TLS for Redis connection",
-    )
-    ttl_minutes: int = Field(
-        default=720,
-        description="TTL for checkpoints in minutes",
-    )
-
-    @property
-    def redis_url(self) -> RedisDsn:
-        """Construct the Redis DSN URL."""
-        return RedisDsn.build(
-            scheme="rediss" if self.secure else "redis",
-            username=None,
-            password=self.password.get_secret_value() if self.password else None,
-            host=self.host,
-            port=self.port,
-            path=f"/{self.db}",
-        )
 
 
 class BackendSettings(AppBaseSettings):
@@ -119,9 +79,9 @@ class BackendSettings(AppBaseSettings):
     )
 
     # === Agent Settings ===
-    checkpointer: RedisCheckpointerSettings = Field(
+    checkpointer: "CheckpointerSettings" = Field(
         description="Settings for the agent's checkpointer, which manages the state of ongoing interactions.",
-        default_factory=RedisCheckpointerSettings,
+        default={"type": "redis"},  # type: ignore
     )
 
     # === Server Settings ===
@@ -159,6 +119,56 @@ class BackendSettings(AppBaseSettings):
         cli_kebab_case=True,
         cli_prog_name="riski",
     )
+
+
+CheckpointerSettings = Annotated[
+    Union["InMemoryCheckpointerSettings", "RedisCheckpointerSettings"],
+    Field(discriminator="type"),
+]
+
+
+class InMemoryCheckpointerSettings(BaseModel):
+    type: Literal["in_memory"] = "in_memory"
+
+
+class RedisCheckpointerSettings(BaseModel):
+    type: Literal["redis"] = "redis"
+    host: str = Field(
+        default="localhost",
+        description="Redis host for checkpointer",
+    )
+    port: int = Field(
+        default=6379,
+        description="Redis port for checkpointer",
+    )
+    db: int = Field(
+        default=0,
+        description="Redis database number for checkpointer",
+    )
+    password: SecretStr | None = Field(
+        default=None,
+        description="Redis password for checkpointer",
+    )
+    secure: bool = Field(
+        default=False,
+        description="Use SSL/TLS for Redis connection",
+    )
+    ttl_minutes: int = Field(
+        default=720,
+        description="TTL for checkpoints in minutes",
+    )
+
+    @property
+    def redis_url(self) -> RedisDsn:
+        """Construct the Redis DSN URL."""
+        return RedisDsn.build(
+            scheme="rediss" if self.secure else "redis",
+            username=None,
+            password=self.password.get_secret_value() if self.password else None,
+            host=self.host,
+            port=self.port,
+            path=f"/{self.db}",
+        )
 
 
 @lru_cache(maxsize=1)

--- a/riski-backend/test/unit/test_checkpointer_settings.py
+++ b/riski-backend/test/unit/test_checkpointer_settings.py
@@ -1,5 +1,5 @@
 import pytest
-from app.core.settings import BackendSettings, InMemoryCheckpointerSettings, RedisCheckpointerSettings, get_settings
+from app.core.settings import BackendSettings, RedisCheckpointerSettings, get_settings
 
 
 @pytest.fixture(autouse=True)
@@ -38,15 +38,15 @@ def _base_env(monkeypatch: pytest.MonkeyPatch, *, host_env: str | None = None, t
 
 
 @pytest.mark.usefixtures("clear_settings_cache")
-def test_checkpointer_default_is_in_memory(monkeypatch: pytest.MonkeyPatch):
-    """Default checkpointer settings should be in_memory when no env vars are present."""
+def test_checkpointer_default_is_redis(monkeypatch: pytest.MonkeyPatch):
+    """Default checkpointer settings should be redis when no env vars are present."""
 
     _base_env(monkeypatch, host_env=None)
 
     settings = get_settings()
 
-    assert isinstance(settings.checkpointer, InMemoryCheckpointerSettings)
-    assert settings.checkpointer.type == "in_memory"
+    assert isinstance(settings.checkpointer, RedisCheckpointerSettings)
+    assert settings.checkpointer.type == "redis"
 
 
 @pytest.mark.usefixtures("clear_settings_cache")


### PR DESCRIPTION
make redis default checkpointer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default checkpoint storage now uses Redis instead of in-memory. Deployments without explicit configuration will start using Redis by default; if you rely on in-memory behavior, update your configuration to restore prior behavior or provide Redis connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->